### PR TITLE
Setting the status to passing for rebooting rds instances

### DIFF
--- a/service/rds/writer.go
+++ b/service/rds/writer.go
@@ -127,7 +127,7 @@ func (r *RDS) writeBackendCatalog(instance *config.DBInstance, logger *log.Entry
 	case "failed":
 		status = "critical"
 	case "rebooting":
-		status = "critical"
+		status = "passing"
 	case "renaming":
 		status = "critical"
 	case "restore-error":


### PR DESCRIPTION
Instances do not become unavailable in the seconds the status changes to rebooting,
so de-registering the service from consul can actually be more harm that worth.

Additionally, if the RDS instance is configured with Multi-AZ failover, rebooting the
instance should actaully never mean a change in the passing status of the service.