### PR TITLE
Add support for multi-value filters

### DIFF
--- a/backend/consul/reader.go
+++ b/backend/consul/reader.go
@@ -54,7 +54,7 @@ func (b *Backend) CatalogReader(state *config.CatalogState, consulNodeName strin
 				continue
 			}
 
-			logger.Debug("Wait index is changed (%d <> %d)", localWaitIndex, remoteWaitIndex)
+			logger.Debugf("Wait index is changed (%d <> %d)", localWaitIndex, remoteWaitIndex)
 			q.WaitIndex = remoteWaitIndex
 
 			state.Lock()
@@ -78,8 +78,12 @@ func processCatalog(n internalNode) config.Services {
 	}
 
 	for _, check := range n.Checks {
+		if check.CheckID == "serfHealth" {
+			continue
+		}
+
 		if _, ok := services[check.ServiceID]; !ok {
-			log.Fatalf("Could not find a service %s for check %s", check.ServiceID, check.CheckID)
+			log.Fatalf("Could not find a service '%s' for check '%s'", check.ServiceID, check.CheckID)
 		}
 
 		services[check.ServiceID].CheckID = check.CheckID

--- a/config/filters.go
+++ b/config/filters.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"fmt"
 	"log"
 	"strings"
 )
@@ -18,7 +19,8 @@ func ProcessFilters(userFilters []string) Filters {
 		name := split[0]
 
 		if _, ok := results[name]; ok {
-			log.Fatalf("Duplicate filer name %s", name)
+			results[name] = fmt.Sprintf("%s,%s", results[name], split[1])
+			continue
 		}
 
 		results[name] = split[1]


### PR DESCRIPTION
All instance filters accept a comma separated list of values now

`aws-dynamic-consul-catalog --instance-filter VpcId=vpc-xxxx,vpc-yyyy --consul-service-prefix db- rds`

and 

`aws-dynamic-consul-catalog --instance-filter VpcId=vpc-xxxx --instance-filter VpcId=vpc-yyyy --consul-service-prefix db- rds`

will be treated the same

Signed-off-by: Christian Winther <jippignu@gmail.com>