### PR TITLE
Fix --instance-filter short-circuit

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"fmt"
 	"os"
+	"runtime/debug"
 	"time"
 
 	"github.com/seatgeek/aws-dynamic-consul-catalog/service/rds"
@@ -10,9 +12,22 @@ import (
 
 func main() {
 	app := cli.NewApp()
-	app.Name = "consul-aws-catalog"
+	app.Name = "aws-dynamic-consul-catalog"
 	app.Usage = "Easily maintain AWS RDS information in Consul service catalog"
 	app.Version = "0.1"
+
+	if info, ok := debug.ReadBuildInfo(); ok {
+		for _, setting := range info.Settings {
+			switch setting.Key {
+			case "vcs.revision":
+				app.Version = setting.Value
+			case "vcs.time":
+				if compileTime, err := time.Parse(time.RFC3339, setting.Value); err != nil {
+					app.Compiled = compileTime
+				}
+			}
+		}
+	}
 
 	app.Flags = []cli.Flag{
 		cli.StringSliceFlag{

--- a/main.go
+++ b/main.go
@@ -17,12 +17,12 @@ func main() {
 	app.Flags = []cli.Flag{
 		cli.StringSliceFlag{
 			Name:   "instance-filter",
-			Usage:  "AWS filters",
+			Usage:  "filters to match AWS DB instance fields",
 			EnvVar: "INSTANCE_FILTER",
 		},
 		cli.StringSliceFlag{
 			Name:   "tag-filter",
-			Usage:  "AWS tag filters",
+			Usage:  "filters to match AWS DB instance tags",
 			EnvVar: "TAG_FILTER",
 		},
 		cli.StringFlag{

--- a/service/rds/filter.go
+++ b/service/rds/filter.go
@@ -46,31 +46,38 @@ func (r *RDS) filter(all, filtered observer.Property) {
 	}
 }
 
+// Returns true if the instance matches all filters provided. If no filters are provided, returns true.
 func (r *RDS) filterByInstanceData(instance *config.DBInstance, filters config.Filters) bool {
 	if len(filters) == 0 {
 		return true
 	}
 
 	for k, filter := range filters {
+		isMatch := false
+
 		switch k {
 		case "AvailabilityZone":
-			return r.matches(filter, aws.StringValue(instance.AvailabilityZone))
+			isMatch = r.matches(filter, aws.StringValue(instance.AvailabilityZone))
 		case "DBInstanceArn":
-			return r.matches(filter, aws.StringValue(instance.DBInstanceArn))
+			isMatch = r.matches(filter, aws.StringValue(instance.DBInstanceArn))
 		case "DBInstanceClass":
-			return r.matches(filter, aws.StringValue(instance.DBInstanceClass))
+			isMatch = r.matches(filter, aws.StringValue(instance.DBInstanceClass))
 		case "DBInstanceIdentifier":
-			return r.matches(filter, aws.StringValue(instance.DBInstanceIdentifier))
+			isMatch = r.matches(filter, aws.StringValue(instance.DBInstanceIdentifier))
 		case "DBInstanceStatus":
-			return r.matches(filter, aws.StringValue(instance.DBInstanceStatus))
+			isMatch = r.matches(filter, aws.StringValue(instance.DBInstanceStatus))
 		case "Engine":
-			return r.matches(filter, aws.StringValue(instance.Engine))
+			isMatch = r.matches(filter, aws.StringValue(instance.Engine))
 		case "EngineVersion":
-			return r.matches(filter, aws.StringValue(instance.EngineVersion))
+			isMatch = r.matches(filter, aws.StringValue(instance.EngineVersion))
 		case "VpcId":
-			return r.matches(filter, aws.StringValue(instance.DBSubnetGroup.VpcId))
+			isMatch = r.matches(filter, aws.StringValue(instance.DBSubnetGroup.VpcId))
 		default:
-			log.Fatalf("Unknown instance filter key %s (%s)", k, filter)
+			log.Warnf("Unknown instance filter key %s (%s)", k, filter)
+		}
+
+		if !isMatch {
+			return false
 		}
 	}
 


### PR DESCRIPTION
Fixes a bug in instance filtering, where the first matched filter would shortcircuit further attribute matching.

Also pictured are some tiny quality-of-life improvements to the build.